### PR TITLE
Add helper script for staging branch management

### DIFF
--- a/create_staging_branch.sh
+++ b/create_staging_branch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Utility script to create or update a local staging branch from the current branch.
+set -euo pipefail
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+if git show-ref --quiet refs/heads/staging; then
+  echo "Updating existing staging branch from $current_branch"
+  git branch -f staging "$current_branch"
+else
+  echo "Creating staging branch from $current_branch"
+  git branch staging "$current_branch"
+fi
+
+echo "Done. You can checkout the staging branch with: git checkout staging"


### PR DESCRIPTION
## Summary
- add a helper script that (re)creates a local staging branch from the current branch
- print messaging to clarify when the staging branch is created or updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcb41a01248326a881714637e2979e