### PR TITLE
Add schema verification log for schema initialization run

### DIFF
--- a/schema_check.log
+++ b/schema_check.log
@@ -1,0 +1,1073 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.11.12, pytest-8.2.1, pluggy-1.6.0 -- /root/.pyenv/versions/3.11.12/bin/python
+cachedir: .pytest_cache
+rootdir: /workspace/snooker-tournaments-hybrid
+configfile: pytest.ini
+testpaths: tests
+plugins: cov-4.1.0, anyio-4.11.0, asyncio-0.22.0
+asyncio: mode=Mode.STRICT
+collecting ... collected 17 items
+
+tests/test_api_flow.py::test_api_flow FAILED                                                                             [  5%]
+tests/test_crud_players.py::test_create_and_get_player PASSED                                                            [ 11%]
+tests/test_players.py::test_wallet_transaction_history FAILED                                                            [ 17%]
+tests/test_players.py::test_balance_and_elo_endpoints FAILED                                                             [ 23%]
+tests/test_players.py::test_leaderboard_endpoint FAILED                                                                  [ 29%]
+tests/test_seed.py::test_seeded_players_exist PASSED                                                                     [ 35%]
+tests/test_services_elo.py::test_elo_update_basic PASSED                                                                 [ 41%]
+tests/test_services_elo.py::test_elo_underdog_wins FAILED                                                                [ 47%]
+tests/test_services_elo.py::test_elo_favorite_wins FAILED                                                                [ 52%]
+tests/test_services_matches.py::test_update_match_result_and_elo FAILED                                                  [ 58%]
+tests/test_services_tournaments.py::test_generate_knockout_matches_even FAILED                                           [ 64%]
+tests/test_services_tournaments.py::test_generate_knockout_matches_odd FAILED                                            [ 70%]
+tests/test_services_tournaments.py::test_distribute_prizes FAILED                                                        [ 76%]
+tests/test_services_wallet.py::test_wallet_flow FAILED                                                                   [ 82%]
+tests/test_tournament_flow.py::test_full_tournament_flow FAILED                                                          [ 88%]
+tests/test_tournament_flow.py::test_register_same_player_twice FAILED                                                    [ 94%]
+tests/test_tournament_flow.py::test_complete_tournament_with_invalid_player FAILED                                       [100%]
+
+=========================================================== FAILURES ===========================================================
+________________________________________________________ test_api_flow _________________________________________________________
+
+    @pytest.mark.asyncio
+    async def test_api_flow():
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            # 1. Create players + deposit balance
+            player_ids = []
+            for name in ["Ronnie", "Selby"]:
+                r = await client.post("/players/", json={"name": name})
+>               assert r.status_code == 200
+E               assert 403 == 200
+E                +  where 403 = <Response [403 Forbidden]>.status_code
+
+tests/test_api_flow.py:15: AssertionError
+_______________________________________________ test_wallet_transaction_history ________________________________________________
+
+    def test_wallet_transaction_history():
+        r = client.post("/players/", json={"name": "LogTest"})
+        pid = r.json()["id"]
+    
+        client.post(f"/players/{pid}/deposit", json={"amount": 100})
+        client.post(f"/players/{pid}/deposit", json={"amount": 50})
+        client.post(f"/players/{pid}/withdraw", json={"amount": 30})
+    
+        r = client.get(f"/players/{pid}/transactions")
+        data = r.json()
+>       assert len(data) == 3
+E       assert 0 == 3
+E        +  where 0 = len([])
+
+tests/test_players.py:18: AssertionError
+________________________________________________ test_balance_and_elo_endpoints ________________________________________________
+
+    def test_balance_and_elo_endpoints():
+        # Create player
+        r = client.post("/players/", json={"name": "StatMan"})
+        assert r.status_code == 200
+        pid = r.json()["id"]
+    
+        # Deposit to wallet
+        r = client.post(f"/players/{pid}/deposit", json={"amount": 150})
+>       assert r.status_code == 200
+E       assert 404 == 200
+E        +  where 404 = <Response [404 Not Found]>.status_code
+
+tests/test_players.py:32: AssertionError
+__________________________________________________ test_leaderboard_endpoint ___________________________________________________
+
+    def test_leaderboard_endpoint():
+        db = SessionLocal()
+        # Create players with Elo directly set
+        players = []
+        for name, elo in [("Alice", 1800), ("Bob", 1500), ("Carl", 1700)]:
+            p = Player(name=name, elo=elo)
+            db.add(p)
+            db.flush()
+            players.append(p)
+        db.commit()
+        db.close()
+    
+        # Call leaderboard endpoint
+        r = client.get("/players/leaderboard")
+>       assert r.status_code == 200
+E       assert 422 == 200
+E        +  where 422 = <Response [422 Unprocessable Entity]>.status_code
+
+tests/test_players.py:58: AssertionError
+____________________________________________________ test_elo_underdog_wins ____________________________________________________
+
+    def test_elo_underdog_wins():
+        winner, loser = update_elo_ratings(1300, 1700)
+>       assert winner > 1300 + 30  # big underdog win
+E       assert 1329 > (1300 + 30)
+
+tests/test_services_elo.py:13: AssertionError
+____________________________________________________ test_elo_favorite_wins ____________________________________________________
+
+    def test_elo_favorite_wins():
+        winner, loser = update_elo_ratings(1700, 1300)
+        assert winner < 1700 + 10  # expected outcome, small change
+>       assert loser > 1300 - 10
+E       assert 1271 > (1300 - 10)
+
+tests/test_services_elo.py:20: AssertionError
+_______________________________________________ test_update_match_result_and_elo _______________________________________________
+
+self = <sqlalchemy.engine.base.Connection object at 0x7f3cd02d2750>
+dialect = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+context = <sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext object at 0x7f3cd02d1350>
+
+    def _exec_insertmany_context(
+        self,
+        dialect: Dialect,
+        context: ExecutionContext,
+    ) -> CursorResult[Any]:
+        """continue the _execute_context() method for an "insertmanyvalues"
+        operation, which will invoke DBAPI
+        cursor.execute() one or more times with individual log and
+        event hook calls.
+    
+        """
+    
+        if dialect.bind_typing is BindTyping.SETINPUTSIZES:
+            generic_setinputsizes = context._prepare_set_input_sizes()
+        else:
+            generic_setinputsizes = None
+    
+        cursor, str_statement, parameters = (
+            context.cursor,
+            context.statement,
+            context.parameters,
+        )
+    
+        effective_parameters = parameters
+    
+        engine_events = self._has_events or self.engine._has_events
+        if self.dialect._has_events:
+            do_execute_dispatch: Iterable[Any] = (
+                self.dialect.dispatch.do_execute
+            )
+        else:
+            do_execute_dispatch = ()
+    
+        if self._echo:
+            stats = context._get_cache_stats() + " (insertmanyvalues)"
+    
+        preserve_rowcount = context.execution_options.get(
+            "preserve_rowcount", False
+        )
+        rowcount = 0
+    
+        for imv_batch in dialect._deliver_insertmanyvalues_batches(
+            cursor,
+            str_statement,
+            effective_parameters,
+            generic_setinputsizes,
+            context,
+        ):
+            if imv_batch.processed_setinputsizes:
+                try:
+                    dialect.do_set_input_sizes(
+                        context.cursor,
+                        imv_batch.processed_setinputsizes,
+                        context,
+                    )
+                except BaseException as e:
+                    self._handle_dbapi_exception(
+                        e,
+                        sql_util._long_statement(imv_batch.replaced_statement),
+                        imv_batch.replaced_parameters,
+                        None,
+                        context,
+                    )
+    
+            sub_stmt = imv_batch.replaced_statement
+            sub_params = imv_batch.replaced_parameters
+    
+            if engine_events:
+                for fn in self.dispatch.before_cursor_execute:
+                    sub_stmt, sub_params = fn(
+                        self,
+                        cursor,
+                        sub_stmt,
+                        sub_params,
+                        context,
+                        True,
+                    )
+    
+            if self._echo:
+                self._log_info(sql_util._long_statement(sub_stmt))
+    
+                imv_stats = f""" {imv_batch.batchnum}/{
+                            imv_batch.total_batches
+                } ({
+                    'ordered'
+                    if imv_batch.rows_sorted else 'unordered'
+                }{
+                    '; batch not supported'
+                    if imv_batch.is_downgraded
+                    else ''
+                })"""
+    
+                if imv_batch.batchnum == 1:
+                    stats += imv_stats
+                else:
+                    stats = f"insertmanyvalues{imv_stats}"
+    
+                if not self.engine.hide_parameters:
+                    self._log_info(
+                        "[%s] %r",
+                        stats,
+                        sql_util._repr_params(
+                            sub_params,
+                            batches=10,
+                            ismulti=False,
+                        ),
+                    )
+                else:
+                    self._log_info(
+                        "[%s] [SQL parameters hidden due to "
+                        "hide_parameters=True]",
+                        stats,
+                    )
+    
+            try:
+                for fn in do_execute_dispatch:
+                    if fn(
+                        cursor,
+                        sub_stmt,
+                        sub_params,
+                        context,
+                    ):
+                        break
+                else:
+>                   dialect.do_execute(
+                        cursor,
+                        sub_stmt,
+                        sub_params,
+                        context,
+                    )
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2116: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+cursor = <sqlite3.Cursor object at 0x7f3cd03f8fc0>
+statement = 'INSERT INTO players (name, rating, elo, balance, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id'
+parameters = ('Alice', 1500, 1500, 0.0, '2025-10-25 12:24:29.967445')
+context = <sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext object at 0x7f3cd02d1350>
+
+    def do_execute(self, cursor, statement, parameters, context=None):
+>       cursor.execute(statement, parameters)
+E       sqlite3.IntegrityError: UNIQUE constraint failed: players.name
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:924: IntegrityError
+
+The above exception was the direct cause of the following exception:
+
+    def test_update_match_result_and_elo():
+        db = SessionLocal()
+    
+        t = Tournament(name="EloCup", type="knockout", date="2025-10-10T12:00:00", best_of=5, race_to=3)
+        p1 = Player(name="Alice", elo=1500)
+        p2 = Player(name="Bob", elo=1500)
+        db.add_all([t, p1, p2])
+>       db.commit()
+
+tests/test_services_matches.py:13: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:2017: in commit
+    trans.commit(_to_root=True)
+<string>:2: in commit
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1302: in commit
+    self._prepare_impl()
+<string>:2: in _prepare_impl
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1277: in _prepare_impl
+    self.session.flush()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4341: in flush
+    self._flush(objects)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4476: in _flush
+    with util.safe_reraise():
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py:146: in __exit__
+    raise exc_value.with_traceback(exc_tb)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4437: in _flush
+    flush_context.execute()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:466: in execute
+    rec.execute(self)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:642: in execute
+    util.preloaded.orm_persistence.save_obj(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:93: in save_obj
+    _emit_insert_statements(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:1143: in _emit_insert_statements
+    result = connection.execute(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1418: in execute
+    return meth(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/sql/elements.py:515: in _execute_on_connection
+    return connection._execute_clauseelement(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1640: in _execute_clauseelement
+    ret = self._execute_context(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1844: in _execute_context
+    return self._exec_insertmany_context(dialect, context)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2124: in _exec_insertmany_context
+    self._handle_dbapi_exception(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2353: in _handle_dbapi_exception
+    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2116: in _exec_insertmany_context
+    dialect.do_execute(
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+cursor = <sqlite3.Cursor object at 0x7f3cd03f8fc0>
+statement = 'INSERT INTO players (name, rating, elo, balance, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id'
+parameters = ('Alice', 1500, 1500, 0.0, '2025-10-25 12:24:29.967445')
+context = <sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext object at 0x7f3cd02d1350>
+
+    def do_execute(self, cursor, statement, parameters, context=None):
+>       cursor.execute(statement, parameters)
+E       sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: players.name
+E       [SQL: INSERT INTO players (name, rating, elo, balance, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id]
+E       [parameters: ('Alice', 1500, 1500, 0.0, '2025-10-25 12:24:29.967445')]
+E       (Background on this error at: https://sqlalche.me/e/20/gkpj)
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:924: IntegrityError
+_____________________________________________ test_generate_knockout_matches_even ______________________________________________
+
+self = <sqlalchemy.engine.base.Connection object at 0x7f3ccec0ce50>
+dialect = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+constructor = <bound method DefaultExecutionContext._init_compiled of <class 'sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext'>>
+statement = <sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>
+parameters = [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}]
+execution_options = immutabledict({'compiled_cache': <sqlalchemy.util._collections.LRUCache object at 0x7f3ccd7b03b0>})
+args = (<sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>, [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}], <sqlalchemy.sql.dml.Insert object at 0x7f3ccec0cfd0>, [])
+kw = {'cache_hit': <CacheStats.CACHE_MISS: 1>}, yp = None
+conn = <sqlalchemy.pool.base._ConnectionFairy object at 0x7f3ccd9cb710>
+
+    def _execute_context(
+        self,
+        dialect: Dialect,
+        constructor: Callable[..., ExecutionContext],
+        statement: Union[str, Compiled],
+        parameters: Optional[_AnyMultiExecuteParams],
+        execution_options: _ExecuteOptions,
+        *args: Any,
+        **kw: Any,
+    ) -> CursorResult[Any]:
+        """Create an :class:`.ExecutionContext` and execute, returning
+        a :class:`_engine.CursorResult`."""
+    
+        if execution_options:
+            yp = execution_options.get("yield_per", None)
+            if yp:
+                execution_options = execution_options.union(
+                    {"stream_results": True, "max_row_buffer": yp}
+                )
+        try:
+            conn = self._dbapi_connection
+            if conn is None:
+                conn = self._revalidate_connection()
+    
+>           context = constructor(
+                dialect, self, conn, execution_options, *args, **kw
+            )
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           TypeError: SQLite DateTime type only accepts Python datetime and date objects as input.
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: TypeError
+
+The above exception was the direct cause of the following exception:
+
+    def test_generate_knockout_matches_even():
+        db = SessionLocal()
+>       tournament = create_dummy_tournament(db, player_count=4)
+
+tests/test_services_tournaments.py:34: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/test_services_tournaments.py:18: in create_dummy_tournament
+    db.commit()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:2017: in commit
+    trans.commit(_to_root=True)
+<string>:2: in commit
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1302: in commit
+    self._prepare_impl()
+<string>:2: in _prepare_impl
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1277: in _prepare_impl
+    self.session.flush()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4341: in flush
+    self._flush(objects)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4476: in _flush
+    with util.safe_reraise():
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py:146: in __exit__
+    raise exc_value.with_traceback(exc_tb)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4437: in _flush
+    flush_context.execute()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:466: in execute
+    rec.execute(self)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:642: in execute
+    util.preloaded.orm_persistence.save_obj(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:93: in save_obj
+    _emit_insert_statements(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:1233: in _emit_insert_statements
+    result = connection.execute(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1418: in execute
+    return meth(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/sql/elements.py:515: in _execute_on_connection
+    return connection._execute_clauseelement(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1640: in _execute_clauseelement
+    ret = self._execute_context(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1821: in _execute_context
+    self._handle_dbapi_exception(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2353: in _handle_dbapi_exception
+    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: in _execute_context
+    context = constructor(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           sqlalchemy.exc.StatementError: (builtins.TypeError) SQLite DateTime type only accepts Python datetime and date objects as input.
+E           [SQL: INSERT INTO tournaments (name, date, type, status, best_of, race_to, entry_fee, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)]
+E           [parameters: [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'name': 'Knockout Test', 'type': 'knockout', 'entry_fee': 100, 'race_to': 3}]]
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: StatementError
+______________________________________________ test_generate_knockout_matches_odd ______________________________________________
+
+self = <sqlalchemy.engine.base.Connection object at 0x7f3ccdff7a90>
+dialect = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+constructor = <bound method DefaultExecutionContext._init_compiled of <class 'sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext'>>
+statement = <sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>
+parameters = [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}]
+execution_options = immutabledict({'compiled_cache': <sqlalchemy.util._collections.LRUCache object at 0x7f3ccd7b03b0>})
+args = (<sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>, [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}], <sqlalchemy.sql.dml.Insert object at 0x7f3ccec0cfd0>, [])
+kw = {'cache_hit': <CacheStats.CACHE_HIT: 0>}, yp = None
+conn = <sqlalchemy.pool.base._ConnectionFairy object at 0x7f3ccdcac1d0>
+
+    def _execute_context(
+        self,
+        dialect: Dialect,
+        constructor: Callable[..., ExecutionContext],
+        statement: Union[str, Compiled],
+        parameters: Optional[_AnyMultiExecuteParams],
+        execution_options: _ExecuteOptions,
+        *args: Any,
+        **kw: Any,
+    ) -> CursorResult[Any]:
+        """Create an :class:`.ExecutionContext` and execute, returning
+        a :class:`_engine.CursorResult`."""
+    
+        if execution_options:
+            yp = execution_options.get("yield_per", None)
+            if yp:
+                execution_options = execution_options.union(
+                    {"stream_results": True, "max_row_buffer": yp}
+                )
+        try:
+            conn = self._dbapi_connection
+            if conn is None:
+                conn = self._revalidate_connection()
+    
+>           context = constructor(
+                dialect, self, conn, execution_options, *args, **kw
+            )
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           TypeError: SQLite DateTime type only accepts Python datetime and date objects as input.
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: TypeError
+
+The above exception was the direct cause of the following exception:
+
+    def test_generate_knockout_matches_odd():
+        db = SessionLocal()
+>       tournament = create_dummy_tournament(db, player_count=5)
+
+tests/test_services_tournaments.py:42: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/test_services_tournaments.py:18: in create_dummy_tournament
+    db.commit()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:2017: in commit
+    trans.commit(_to_root=True)
+<string>:2: in commit
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1302: in commit
+    self._prepare_impl()
+<string>:2: in _prepare_impl
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1277: in _prepare_impl
+    self.session.flush()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4341: in flush
+    self._flush(objects)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4476: in _flush
+    with util.safe_reraise():
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py:146: in __exit__
+    raise exc_value.with_traceback(exc_tb)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4437: in _flush
+    flush_context.execute()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:466: in execute
+    rec.execute(self)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:642: in execute
+    util.preloaded.orm_persistence.save_obj(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:93: in save_obj
+    _emit_insert_statements(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:1233: in _emit_insert_statements
+    result = connection.execute(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1418: in execute
+    return meth(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/sql/elements.py:515: in _execute_on_connection
+    return connection._execute_clauseelement(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1640: in _execute_clauseelement
+    ret = self._execute_context(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1821: in _execute_context
+    self._handle_dbapi_exception(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2353: in _handle_dbapi_exception
+    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: in _execute_context
+    context = constructor(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           sqlalchemy.exc.StatementError: (builtins.TypeError) SQLite DateTime type only accepts Python datetime and date objects as input.
+E           [SQL: INSERT INTO tournaments (name, date, type, status, best_of, race_to, entry_fee, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)]
+E           [parameters: [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'name': 'Knockout Test', 'type': 'knockout', 'entry_fee': 100, 'race_to': 3}]]
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: StatementError
+____________________________________________________ test_distribute_prizes ____________________________________________________
+
+self = <sqlalchemy.engine.base.Connection object at 0x7f3cce1a9550>
+dialect = <sqlalchemy.dialects.sqlite.pysqlite.SQLiteDialect_pysqlite object at 0x7f3cd0f48890>
+constructor = <bound method DefaultExecutionContext._init_compiled of <class 'sqlalchemy.dialects.sqlite.base.SQLiteExecutionContext'>>
+statement = <sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>
+parameters = [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}]
+execution_options = immutabledict({'compiled_cache': <sqlalchemy.util._collections.LRUCache object at 0x7f3ccd7b03b0>})
+args = (<sqlalchemy.dialects.sqlite.base.SQLiteCompiler object at 0x7f3ccec0ddd0>, [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'entry_fee': 100, 'name': 'Knockout Test', ...}], <sqlalchemy.sql.dml.Insert object at 0x7f3ccec0cfd0>, [])
+kw = {'cache_hit': <CacheStats.CACHE_HIT: 0>}, yp = None
+conn = <sqlalchemy.pool.base._ConnectionFairy object at 0x7f3ccf7320f0>
+
+    def _execute_context(
+        self,
+        dialect: Dialect,
+        constructor: Callable[..., ExecutionContext],
+        statement: Union[str, Compiled],
+        parameters: Optional[_AnyMultiExecuteParams],
+        execution_options: _ExecuteOptions,
+        *args: Any,
+        **kw: Any,
+    ) -> CursorResult[Any]:
+        """Create an :class:`.ExecutionContext` and execute, returning
+        a :class:`_engine.CursorResult`."""
+    
+        if execution_options:
+            yp = execution_options.get("yield_per", None)
+            if yp:
+                execution_options = execution_options.union(
+                    {"stream_results": True, "max_row_buffer": yp}
+                )
+        try:
+            conn = self._dbapi_connection
+            if conn is None:
+                conn = self._revalidate_connection()
+    
+>           context = constructor(
+                dialect, self, conn, execution_options, *args, **kw
+            )
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           TypeError: SQLite DateTime type only accepts Python datetime and date objects as input.
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: TypeError
+
+The above exception was the direct cause of the following exception:
+
+    def test_distribute_prizes():
+        db = SessionLocal()
+>       tournament = create_dummy_tournament(db, player_count=3)
+
+tests/test_services_tournaments.py:52: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/test_services_tournaments.py:18: in create_dummy_tournament
+    db.commit()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:2017: in commit
+    trans.commit(_to_root=True)
+<string>:2: in commit
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1302: in commit
+    self._prepare_impl()
+<string>:2: in _prepare_impl
+    ???
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/state_changes.py:139: in _go
+    ret_value = fn(self, *arg, **kw)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:1277: in _prepare_impl
+    self.session.flush()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4341: in flush
+    self._flush(objects)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4476: in _flush
+    with util.safe_reraise():
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/util/langhelpers.py:146: in __exit__
+    raise exc_value.with_traceback(exc_tb)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/session.py:4437: in _flush
+    flush_context.execute()
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:466: in execute
+    rec.execute(self)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/unitofwork.py:642: in execute
+    util.preloaded.orm_persistence.save_obj(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:93: in save_obj
+    _emit_insert_statements(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/orm/persistence.py:1233: in _emit_insert_statements
+    result = connection.execute(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1418: in execute
+    return meth(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/sql/elements.py:515: in _execute_on_connection
+    return connection._execute_clauseelement(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1640: in _execute_clauseelement
+    ret = self._execute_context(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1821: in _execute_context
+    self._handle_dbapi_exception(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2353: in _handle_dbapi_exception
+    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1815: in _execute_context
+    context = constructor(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1457: in _init_compiled
+    l_param: List[Any] = [
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/engine/default.py:1459: in <listcomp>
+    flattened_processors[key](compiled_params[key])
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+value = '2025-10-01T12:00:00'
+
+    def process(value):
+        if value is None:
+            return None
+        elif isinstance(value, datetime_datetime):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": value.hour,
+                "minute": value.minute,
+                "second": value.second,
+                "microsecond": value.microsecond,
+            }
+        elif isinstance(value, datetime_date):
+            return format_ % {
+                "year": value.year,
+                "month": value.month,
+                "day": value.day,
+                "hour": 0,
+                "minute": 0,
+                "second": 0,
+                "microsecond": 0,
+            }
+        else:
+>           raise TypeError(
+                "SQLite DateTime type only accepts Python "
+                "datetime and date objects as input."
+            )
+E           sqlalchemy.exc.StatementError: (builtins.TypeError) SQLite DateTime type only accepts Python datetime and date objects as input.
+E           [SQL: INSERT INTO tournaments (name, date, type, status, best_of, race_to, entry_fee, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)]
+E           [parameters: [{'best_of': 5, 'date': '2025-10-01T12:00:00', 'name': 'Knockout Test', 'type': 'knockout', 'entry_fee': 100, 'race_to': 3}]]
+
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/sqlalchemy/dialects/sqlite/base.py:1068: StatementError
+_______________________________________________________ test_wallet_flow _______________________________________________________
+
+    def test_wallet_flow():
+        db = SessionLocal()
+        player = Player(name="Wallet Test")
+        db.add(player)
+        db.commit()
+        db.refresh(player)
+    
+        pid = player.id
+    
+        # Initial balance should be 0
+        assert wallet.get_balance(db, pid) == 0.0
+    
+        # Deposit
+        wallet.deposit(db, pid, 100.0)
+>       assert wallet.get_balance(db, pid) == 100.0
+E       assert 0.0 == 100.0
+E        +  where 0.0 = <function get_balance at 0x7f3cd00d9580>(<sqlalchemy.orm.session.Session object at 0x7f3ccd7d4990>, 13)
+E        +    where <function get_balance at 0x7f3cd00d9580> = wallet.get_balance
+
+tests/test_services_wallet.py:20: AssertionError
+__________________________________________________ test_full_tournament_flow ___________________________________________________
+
+    def test_full_tournament_flow():
+        # Create players
+        for i in range(1, 5):
+            r = client.post("/players/", json={"name": f"Player {i}"})
+>           assert r.status_code == 200, f"Player creation failed: {r.text}"
+E           AssertionError: Player creation failed: {"detail":"Player 'Player 1' already exists"}
+E           assert 400 == 200
+E            +  where 400 = <Response [400 Bad Request]>.status_code
+
+tests/test_tournament_flow.py:19: AssertionError
+_______________________________________________ test_register_same_player_twice ________________________________________________
+
+    def test_register_same_player_twice():
+        # Create player
+        r = client.post("/players/", json={"name": "Player 1"})
+>       assert r.status_code == 200
+E       assert 400 == 200
+E        +  where 400 = <Response [400 Bad Request]>.status_code
+
+tests/test_tournament_flow.py:57: AssertionError
+_________________________________________ test_complete_tournament_with_invalid_player _________________________________________
+
+    def test_complete_tournament_with_invalid_player():
+        tournament_data = {
+            "name": unique_name("Invalid Winners Test"),
+            "type": "knockout",
+            "date": "2025-09-17T12:00:00",
+            "best_of": 5,
+            "race_to": 3,
+            "entry_fee": 50,
+        }
+        response = client.post("/tournaments/", json=tournament_data)
+        assert response.status_code == 200, f"Unexpected response: {response.text}"
+        tournament_id = response.json()["id"]
+    
+        # Register valid players
+        for pid in [1, 2]:
+>           client.post(f"/tournaments/{tournament_id}/register", json={"player_id": pid, "tournament_id": tournament_id})
+
+tests/test_tournament_flow.py:105: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/testclient.py:633: in post
+    return super().post(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:1145: in post
+    return self.request(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/testclient.py:516: in request
+    return super().request(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:827: in request
+    return self.send(request, auth=auth, follow_redirects=follow_redirects)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:914: in send
+    response = self._send_handling_auth(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:942: in _send_handling_auth
+    response = self._send_handling_redirects(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:979: in _send_handling_redirects
+    response = self._send_single_request(request)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:1015: in _send_single_request
+    response = transport.handle_request(request)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/testclient.py:398: in handle_request
+    raise exc
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/testclient.py:395: in handle_request
+    portal.call(self.app, scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/anyio/from_thread.py:321: in call
+    return cast(T_Retval, self.start_task_soon(func, *args).result())
+/root/.pyenv/versions/3.11.12/lib/python3.11/concurrent/futures/_base.py:456: in result
+    return self.__get_result()
+/root/.pyenv/versions/3.11.12/lib/python3.11/concurrent/futures/_base.py:401: in __get_result
+    raise self._exception
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/anyio/from_thread.py:252: in _call_func
+    retval = await retval_or_awaitable
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/fastapi/applications.py:1054: in __call__
+    await super().__call__(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/applications.py:123: in __call__
+    await self.middleware_stack(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/middleware/errors.py:186: in __call__
+    raise exc
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/middleware/errors.py:164: in __call__
+    await self.app(scope, receive, _send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/middleware/exceptions.py:65: in __call__
+    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/_exception_handler.py:64: in wrapped_app
+    raise exc
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/_exception_handler.py:53: in wrapped_app
+    await app(scope, receive, sender)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/routing.py:756: in __call__
+    await self.middleware_stack(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/routing.py:776: in app
+    await route.handle(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/routing.py:297: in handle
+    await self.app(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/routing.py:77: in app
+    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/_exception_handler.py:64: in wrapped_app
+    raise exc
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/_exception_handler.py:53: in wrapped_app
+    await app(scope, receive, sender)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/routing.py:72: in app
+    response = await func(request)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/fastapi/routing.py:278: in app
+    raw_response = await run_endpoint_function(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/fastapi/routing.py:193: in run_endpoint_function
+    return await run_in_threadpool(dependant.call, **values)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/concurrency.py:42: in run_in_threadpool
+    return await anyio.to_thread.run_sync(func, *args)
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/anyio/to_thread.py:56: in run_sync
+    return await get_async_backend().run_sync_in_worker_thread(
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/anyio/_backends/_asyncio.py:2485: in run_sync_in_worker_thread
+    return await future
+/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/anyio/_backends/_asyncio.py:976: in run
+    result = context.run(func, *args)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+tournament_id = 2, registration = TournamentRegistrationCreate(player_id=1)
+db = <sqlalchemy.orm.session.Session object at 0x7f3cce0386d0>
+
+    @router.post("/{tournament_id}/register")
+    def register_player(
+        tournament_id: int,
+        registration: TournamentRegistrationCreate,
+        db: Session = Depends(get_db)
+    ):
+>       tournament = crud.get_tournament(db, tournament_id)
+E       AttributeError: module 'app.crud' has no attribute 'get_tournament'
+
+app/routes/tournaments.py:29: AttributeError
+======================================================= warnings summary =======================================================
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:12
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/starlette/formparsers.py:12: PendingDeprecationWarning: Please use `import python_multipart` instead.
+    import multipart
+
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/pydantic/_internal/_config.py:284: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
+    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
+
+app/main.py:13
+  /workspace/snooker-tournaments-hybrid/app/main.py:13: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("startup")
+
+../../root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/fastapi/applications.py:4495
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/fastapi/applications.py:4495: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)
+
+tests/test_api_flow.py::test_api_flow
+  /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/httpx/_client.py:1426: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=ASGITransport(app=...)' instead.
+    warnings.warn(message, DeprecationWarning)
+
+tests/test_players.py::test_wallet_transaction_history
+  /workspace/snooker-tournaments-hybrid/app/routes/players.py:58: LegacyAPIWarning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0. The method is now available as Session.get() (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    player = db.query(models.Player).get(player_id)
+
+tests/test_services_wallet.py::test_wallet_flow
+tests/test_services_wallet.py::test_wallet_flow
+  /workspace/snooker-tournaments-hybrid/app/services/wallet.py:7: LegacyAPIWarning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0. The method is now available as Session.get() (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
+    player = db.query(Player).get(player_id)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=================================================== short test summary info ====================================================
+FAILED tests/test_api_flow.py::test_api_flow - assert 403 == 200
+FAILED tests/test_players.py::test_wallet_transaction_history - assert 0 == 3
+FAILED tests/test_players.py::test_balance_and_elo_endpoints - assert 404 == 200
+FAILED tests/test_players.py::test_leaderboard_endpoint - assert 422 == 200
+FAILED tests/test_services_elo.py::test_elo_underdog_wins - assert 1329 > (1300 + 30)
+FAILED tests/test_services_elo.py::test_elo_favorite_wins - assert 1271 > (1300 - 10)
+FAILED tests/test_services_matches.py::test_update_match_result_and_elo - sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityEr...
+FAILED tests/test_services_tournaments.py::test_generate_knockout_matches_even - sqlalchemy.exc.StatementError: (builtins.Typ...
+FAILED tests/test_services_tournaments.py::test_generate_knockout_matches_odd - sqlalchemy.exc.StatementError: (builtins.Type...
+FAILED tests/test_services_tournaments.py::test_distribute_prizes - sqlalchemy.exc.StatementError: (builtins.TypeError) SQLit...
+FAILED tests/test_services_wallet.py::test_wallet_flow - assert 0.0 == 100.0
+FAILED tests/test_tournament_flow.py::test_full_tournament_flow - AssertionError: Player creation failed: {"detail":"Player '...
+FAILED tests/test_tournament_flow.py::test_register_same_player_twice - assert 400 == 200
+FAILED tests/test_tournament_flow.py::test_complete_tournament_with_invalid_player - AttributeError: module 'app.crud' has no...
+========================================== 14 failed, 3 passed, 13 warnings in 4.27s ===========================================


### PR DESCRIPTION
## Summary
- reset the SQLite databases and recreated the ORM schema
- inserted sample player, tournament, and match records to validate table creation
- ran the test suite and captured the output in schema_check.log for troubleshooting

## Testing
- pytest -v (fails, see schema_check.log)


------
https://chatgpt.com/codex/tasks/task_e_68fcc161b39c8326a390b969724b9dd9