### PR TITLE
Implement tournament, wallet, and leaderboard fixes

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -28,10 +28,14 @@ def create_tournament(db: Session, tournament: schemas.TournamentCreate):
     if existing:
         raise HTTPException(status_code=400, detail=f"A tournament named '{tournament.name}' already exists.")
     # normalize type string to enum-like value (models expect enum names values at DB layer)
+    tournament_date = tournament.date
+    if isinstance(tournament_date, str):
+        tournament_date = datetime.fromisoformat(tournament_date)
+
     t = models.Tournament(
         name=tournament.name,
         type=tournament.type,
-        date=tournament.date,
+        date=tournament_date,
         best_of=tournament.best_of,
         race_to=tournament.race_to,
         entry_fee=tournament.entry_fee,
@@ -43,6 +47,10 @@ def create_tournament(db: Session, tournament: schemas.TournamentCreate):
 
 def get_tournaments(db: Session):
     return db.query(models.Tournament).all()
+
+
+def get_tournament(db: Session, tournament_id: int):
+    return db.query(models.Tournament).filter(models.Tournament.id == tournament_id).first()
 
 def register_player(db: Session, tournament_id: int, player_id: int, player_name: str | None = None):
     tournament = db.query(models.Tournament).filter(models.Tournament.id == tournament_id).first()
@@ -139,5 +147,4 @@ def report_result(db: Session, match_id: int, result: schemas.MatchResult):
 def get_matches(db: Session):
     """Return all matches from the database."""
     return db.query(models.Match).all()
-
 

--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base, Session
 # app/database.py
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
 from sqlalchemy import create_engine, MetaData
 
 # (optional) naming convention helps with migrations & alembic
@@ -25,6 +25,9 @@ Base = declarative_base(metadata=metadata)
 SQLALCHEMY_DATABASE_URL = "sqlite:///./snooker.db"
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+# Ensure default SQLite database has tables available for ad-hoc usage
+Base.metadata.create_all(bind=engine)
 
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,28 +1,34 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .database import Base, engine
-from .routes import players, tournaments, matches
-from fastapi import FastAPI
-from .database import engine, Base
-from .routes import players, tournaments, matches
-# create tables (for simple local usage)
 
+from . import models  # noqa: F401  # ensure models are registered with SQLAlchemy metadata
+from .database import Base, engine
+from .routes import matches, players, tournaments
 
 app = FastAPI()
-# Optional: table creation at startup (not recommended for prod)
+
+# Ensure default database tables exist when the module loads.
+Base.metadata.create_all(bind=engine)
+
+
 @app.on_event("startup")
 def on_startup():
     Base.metadata.create_all(bind=engine)
 
+
+# Basic CORS configuration for local development/testing.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(players.router)
 app.include_router(tournaments.router)
 app.include_router(matches.router)
 
-
-
-app.include_router(players.router)
-app.include_router(tournaments.router)
-app.include_router(matches.router)
 
 @app.get("/health")
 def health():

--- a/app/routes/players.py
+++ b/app/routes/players.py
@@ -1,31 +1,53 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-from app import schemas, crud
-from app.database import get_db
-########
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+
+from app import crud, models, schemas
 from app.database import get_db
-from app import crud, models
+from app.services import wallet
 
 router = APIRouter(prefix="/players", tags=["players"])
 
-router = APIRouter(prefix='/players', tags=['players'])
 
-@router.post('/', response_model=schemas.Player)
+@router.post("/", response_model=schemas.Player)
 def create_player(player: schemas.PlayerCreate, db: Session = Depends(get_db)):
     return crud.create_player(db, player)
 
-@router.get('/', response_model=list[schemas.Player])
+
+@router.get("/", response_model=list[schemas.Player])
 def list_players(db: Session = Depends(get_db)):
     return crud.get_players(db)
 
-@router.get('/{player_id}', response_model=schemas.Player)
+
+@router.get("/leaderboard", response_model=list[schemas.PlayerOut])
+def get_leaderboard(db: Session = Depends(get_db)):
+    players = db.query(models.Player).order_by(models.Player.elo.desc()).limit(10).all()
+    return players
+
+
+@router.get("/{player_id}", response_model=schemas.Player)
 def get_player(player_id: int, db: Session = Depends(get_db)):
     return crud.get_player(db, player_id)
-############################################
-@router.get("/{player_id}/balance", response_model=schemas.PlayerBalanceOut)
 
+
+@router.post("/{player_id}/deposit", response_model=schemas.PlayerBalanceOut)
+def deposit(player_id: int, payload: schemas.WalletAmount, db: Session = Depends(get_db)):
+    try:
+        player = wallet.deposit(db, player_id, payload.amount)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"player_id": player.id, "balance": player.balance}
+
+
+@router.post("/{player_id}/withdraw", response_model=schemas.PlayerBalanceOut)
+def withdraw(player_id: int, payload: schemas.WalletAmount, db: Session = Depends(get_db)):
+    try:
+        player = wallet.withdraw(db, player_id, payload.amount)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"player_id": player.id, "balance": player.balance}
+
+
+@router.get("/{player_id}/balance", response_model=schemas.PlayerBalanceOut)
 def get_player_balance(player_id: int, db: Session = Depends(get_db)):
     player = db.query(models.Player).get(player_id)
     if not player:
@@ -34,25 +56,13 @@ def get_player_balance(player_id: int, db: Session = Depends(get_db)):
 
 
 @router.get("/{player_id}/elo", response_model=schemas.PlayerEloOut)
-
 def get_player_elo(player_id: int, db: Session = Depends(get_db)):
     player = db.query(models.Player).get(player_id)
     if not player:
         raise HTTPException(status_code=404, detail="Player not found")
     return {"player_id": player.id, "elo": player.elo}
 
-@router.get("/leaderboard")
-def get_leaderboard(limit: int = 10, db: Session = Depends(get_db)):
-    players = (
-        db.query(models.Player)
-        .order_by(models.Player.elo.desc())
-        .limit(limit)
-        .all()
-    )
-    return [
-        {"player_id": p.id, "name": p.name, "elo": p.elo, "balance": p.balance}
-        for p in players
-    ]
+
 @router.get("/{player_id}/transactions")
 def get_wallet_transactions(player_id: int, db: Session = Depends(get_db)):
     player = db.query(models.Player).get(player_id)
@@ -64,7 +74,7 @@ def get_wallet_transactions(player_id: int, db: Session = Depends(get_db)):
             "id": t.id,
             "type": t.type,
             "amount": t.amount,
-            "timestamp": t.timestamp.isoformat()
+            "timestamp": t.timestamp.isoformat(),
         }
         for t in player.transactions
     ]

--- a/app/routes/tournaments.py
+++ b/app/routes/tournaments.py
@@ -1,30 +1,34 @@
+from datetime import datetime
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import List
+
+from app import crud, schemas
 from app.database import get_db
-from app import crud, models, schemas, schemas, schemas
 from app.schemas import TournamentRegistrationCreate
 from app.services import wallet
 
-
-
 router = APIRouter(prefix="/tournaments", tags=["tournaments"])
 
-router = APIRouter(prefix='/tournaments', tags=['tournaments'])
 
-@router.post('/', response_model=schemas.Tournament)
+@router.post("/", response_model=schemas.Tournament)
 def create_tournament(tournament: schemas.TournamentCreate, db: Session = Depends(get_db)):
+    if isinstance(tournament.date, str):
+        tournament.date = datetime.fromisoformat(tournament.date)
     return crud.create_tournament(db, tournament)
 
-@router.get('/', response_model=List[schemas.Tournament])
+
+@router.get("/", response_model=List[schemas.Tournament])
 def list_tournaments(db: Session = Depends(get_db)):
     return crud.get_tournaments(db)
+
 
 @router.post("/{tournament_id}/register")
 def register_player(
     tournament_id: int,
     registration: TournamentRegistrationCreate,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     tournament = crud.get_tournament(db, tournament_id)
     if not tournament:
@@ -32,8 +36,21 @@ def register_player(
 
     player = crud.get_player(db, registration.player_id)
     if not player:
-            raise HTTPException(status_code=404, detail="Player not found")
+        raise HTTPException(status_code=404, detail="Player not found")
+
+    if tournament.entry_fee:
+        try:
+            wallet.withdraw(db, player.id, tournament.entry_fee)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return crud.register_player(db, tournament_id, registration.player_id)
+
 
 @router.post('/{tournament_id}/complete', response_model=List[schemas.TournamentResult])
-def complete_tournament(tournament_id: int, winners: List[schemas.WinnerCreate], db: Session = Depends(get_db)):
+def complete_tournament(
+    tournament_id: int,
+    winners: List[schemas.WinnerCreate],
+    db: Session = Depends(get_db),
+):
     return crud.complete_tournament(db, tournament_id, winners)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -103,6 +103,9 @@ class TournamentRegistrationCreate(BaseModel):
     player_id: int
 
 
+class WalletAmount(BaseModel):
+    amount: float = Field(..., gt=0)
+
 class PlayerBalanceOut(BaseModel):
     player_id: int
     balance: float
@@ -110,6 +113,15 @@ class PlayerBalanceOut(BaseModel):
 class PlayerEloOut(BaseModel):
     player_id: int
     elo: int
+
+class PlayerOut(BaseModel):
+    id: int
+    name: str
+    elo: int
+    balance: float
+
+    class Config:
+        from_attributes = True
 
 class WalletTransactionOut(BaseModel):
     id: int

--- a/app/services/elo.py
+++ b/app/services/elo.py
@@ -2,15 +2,17 @@ def expected_score(player_rating: float, opponent_rating: float) -> float:
     return 1 / (1 + 10 ** ((opponent_rating - player_rating) / 400))
 
 
-def update_elo_ratings(winner_rating: float, loser_rating: float, k: int = 32) -> tuple[int, int]:
+def update_elo_ratings(winner_rating: float, loser_rating: float, k: int = 40) -> tuple[int, int]:
     expected_win = expected_score(winner_rating, loser_rating)
     expected_loss = expected_score(loser_rating, winner_rating)
 
     new_winner = round(winner_rating + k * (1 - expected_win))
-    new_loser = round(loser_rating + k * (0 - (1 - expected_loss)))
+    new_loser = round(loser_rating + k * (0 - expected_loss))
 
     return new_winner, new_loser
-def elo_update(r_a: float, r_b: float, score_a: float, score_b: float, k: float = 32.0):
+
+
+def elo_update(r_a: float, r_b: float, score_a: float, score_b: float, k: float = 40.0):
     exp_a = 1.0 / (1.0 + 10 ** ((r_b - r_a) / 400.0))
     exp_b = 1.0 / (1.0 + 10 ** ((r_a - r_b) / 400.0))
     return r_a + k * (score_a - exp_a), r_b + k * (score_b - exp_b)

--- a/app/services/wallet.py
+++ b/app/services/wallet.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
-from app.models import Player
-from app.models import WalletTransaction, TransactionType
+
+from app.models import Player, TransactionType, WalletTransaction
 
 
 def get_balance(db: Session, player_id: int) -> float:
@@ -11,15 +11,33 @@ def get_balance(db: Session, player_id: int) -> float:
 
 
 def deposit(db: Session, player_id: int, amount: float):
-    ...
+    if amount <= 0:
+        raise ValueError("Deposit amount must be positive.")
+
+    player = db.query(Player).get(player_id)
+    if not player:
+        raise ValueError(f"Player {player_id} not found.")
+
+    player.balance += amount
     db.add(WalletTransaction(player_id=player_id, type=TransactionType.deposit, amount=amount))
     db.commit()
-    return Player.balance
+    db.refresh(player)
+    return player
 
 
 def withdraw(db: Session, player_id: int, amount: float):
-    ...
+    if amount <= 0:
+        raise ValueError("Withdrawal amount must be positive.")
+
+    player = db.query(Player).get(player_id)
+    if not player:
+        raise ValueError(f"Player {player_id} not found.")
+
+    if player.balance < amount:
+        raise ValueError("Insufficient balance.")
+
+    player.balance -= amount
     db.add(WalletTransaction(player_id=player_id, type=TransactionType.withdrawal, amount=amount))
     db.commit()
-    return Player.balance
-
+    db.refresh(player)
+    return player

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 from app.main import app
-from app.database import SessionLocal
+from tests.conftest import TestingSessionLocal
 from app.models import Player
 
 client = TestClient(app)
@@ -42,7 +42,9 @@ def test_balance_and_elo_endpoints():
     assert r.json()["elo"] == 1500
 
 def test_leaderboard_endpoint():
-    db = SessionLocal()
+    db = TestingSessionLocal()
+    db.query(Player).delete()
+    db.commit()
     # Create players with Elo directly set
     players = []
     for name, elo in [("Alice", 1800), ("Bob", 1500), ("Carl", 1700)]:

--- a/tests/test_services_matches.py
+++ b/tests/test_services_matches.py
@@ -1,29 +1,41 @@
-from app.services.matches import update_match_result
+from datetime import datetime
+from tests.conftest import TestingSessionLocal
 from app.models import Match, Player, Tournament
-from app.database import SessionLocal
+from app.services.matches import update_match_result
 
 
 def test_update_match_result_and_elo():
-    db = SessionLocal()
+    db = TestingSessionLocal()
+    try:
+        db.query(Match).delete()
+        db.query(Tournament).delete()
+        db.query(Player).delete()
+        db.commit()
 
-    t = Tournament(name="EloCup", type="knockout", date="2025-10-10T12:00:00", best_of=5, race_to=3)
-    p1 = Player(name="Alice", elo=1500)
-    p2 = Player(name="Bob", elo=1500)
-    db.add_all([t, p1, p2])
-    db.commit()
-    db.refresh(t)
-    db.refresh(p1)
-    db.refresh(p2)
+        tournament = Tournament(
+            name="EloCup",
+            type="knockout",
+            date=datetime.fromisoformat("2025-10-10T12:00:00"),
+            best_of=5,
+            race_to=3,
+        )
+        player_one = Player(name="Alice", elo=1500)
+        player_two = Player(name="Bob", elo=1500)
+        db.add_all([tournament, player_one, player_two])
+        db.commit()
+        db.refresh(tournament)
+        db.refresh(player_one)
+        db.refresh(player_two)
 
-    match = Match(tournament_id=t.id, player1_id=p1.id, player2_id=p2.id)
-    db.add(match)
-    db.commit()
-    db.refresh(match)
+        match = Match(tournament_id=tournament.id, player1_id=player_one.id, player2_id=player_two.id)
+        db.add(match)
+        db.commit()
+        db.refresh(match)
 
-    updated = update_match_result(db, match.id, winner_id=p1.id)
+        updated = update_match_result(db, match.id, winner_id=player_one.id)
 
-    assert updated.winner_id == p1.id
-    assert db.query(Player).get(p1.id).elo > 1500
-    assert db.query(Player).get(p2.id).elo < 1500
-
-    db.close()
+        assert updated.winner_id == player_one.id
+        assert db.query(Player).get(player_one.id).elo > 1500
+        assert db.query(Player).get(player_two.id).elo < 1500
+    finally:
+        db.close()

--- a/tests/test_services_tournaments.py
+++ b/tests/test_services_tournaments.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 import pytest
 from sqlalchemy.orm import Session
 from app.models import Tournament, Player, TournamentRegistration
-from app.database import SessionLocal
+from tests.conftest import TestingSessionLocal
 from app.services.tournaments import distribute_prizes, generate_knockout_matches
 
 
@@ -9,7 +10,7 @@ def create_dummy_tournament(db: Session, player_count=4) -> Tournament:
     tournament = Tournament(
         name="Knockout Test",
         type="knockout",
-        date="2025-10-01T12:00:00",
+        date=datetime.fromisoformat("2025-10-01T12:00:00"),
         best_of=5,
         race_to=3,
         entry_fee=100,
@@ -30,7 +31,7 @@ def create_dummy_tournament(db: Session, player_count=4) -> Tournament:
 
 
 def test_generate_knockout_matches_even():
-    db = SessionLocal()
+    db = TestingSessionLocal()
     tournament = create_dummy_tournament(db, player_count=4)
     matches = generate_knockout_matches(db, tournament)
     assert len(matches) == 2  # 4 players → 2 matches
@@ -38,7 +39,7 @@ def test_generate_knockout_matches_even():
 
 
 def test_generate_knockout_matches_odd():
-    db = SessionLocal()
+    db = TestingSessionLocal()
     tournament = create_dummy_tournament(db, player_count=5)
     matches = generate_knockout_matches(db, tournament)
     assert len(matches) == 3  # 2 matches + 1 bye
@@ -48,7 +49,7 @@ def test_generate_knockout_matches_odd():
 
 
 def test_distribute_prizes():
-    db = SessionLocal()
+    db = TestingSessionLocal()
     tournament = create_dummy_tournament(db, player_count=3)
     db.refresh(tournament)
 


### PR DESCRIPTION
## Summary
- add a reusable CRUD helper for fetching tournaments and normalize stored dates
- patch tournament registration to charge entry fees via the wallet service with proper error handling
- restructure player routes with wallet endpoints and a schema-backed leaderboard response
- commit wallet balance updates, raise useful validation errors, and raise the ELO K-factor to 40
- ensure default SQLite tables exist on startup and clean up database usage in service tests

## Testing
- `pytest tests/test_services_elo.py -q`
- `pytest tests/test_services_matches.py -q`
- `pytest tests/test_players.py::test_leaderboard_endpoint -q`
- `pytest -v` *(fails: collection stops because tests/test_tournament_flow.py imports perform live API calls before fixtures, leading to 400 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68fcc4cff3f88326958f4dd29881fe43