### PR TITLE
Improve test isolation and dynamic test data

### DIFF
--- a/tests/test_crud_players.py
+++ b/tests/test_crud_players.py
@@ -1,11 +1,11 @@
 from app.crud import create_player, get_player
 from app.schemas import PlayerCreate
-from app.database import SessionLocal
+from tests.conftest import TestingSessionLocal
 from app.models import Player
 
 
 def test_create_and_get_player():
-    db = SessionLocal()
+    db = TestingSessionLocal()
     new_player = PlayerCreate(name="Test Player CRUD")
     created = create_player(db, new_player)
     assert isinstance(created, Player)

--- a/tests/test_services_tournaments.py
+++ b/tests/test_services_tournaments.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import uuid
 import pytest
 from sqlalchemy.orm import Session
 from app.models import Tournament, Player, TournamentRegistration
@@ -8,7 +9,7 @@ from app.services.tournaments import distribute_prizes, generate_knockout_matche
 
 def create_dummy_tournament(db: Session, player_count=4) -> Tournament:
     tournament = Tournament(
-        name="Knockout Test",
+        name=f"Knockout Test_{uuid.uuid4().hex[:6]}",
         type="knockout",
         date=datetime.fromisoformat("2025-10-01T12:00:00"),
         best_of=5,

--- a/tests/test_services_wallet.py
+++ b/tests/test_services_wallet.py
@@ -1,10 +1,10 @@
 from app.services import wallet
 from app.models import Player
-from app.database import SessionLocal
+from tests.conftest import TestingSessionLocal
 
 
 def test_wallet_flow():
-    db = SessionLocal()
+    db = TestingSessionLocal()
     player = Player(name="Wallet Test")
     db.add(player)
     db.commit()


### PR DESCRIPTION
## Summary
- refresh the SQLite test database for every test run via pytest fixtures
- update API and service tests to use randomized names and the shared test session
- add helpers to seed players with deposited balances in tournament flow tests to avoid collisions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68fcccb06b3c832693b883dbb3a8f394