### PR TITLE
Add dev session log for environment initialization

### DIFF
--- a/dev_session_log.md
+++ b/dev_session_log.md
@@ -1,0 +1,53 @@
+# 🧱 Initialize Snooker Tournaments Hybrid Dev Session
+
+## Environment Versions
+- Python: 3.11.12
+- Pytest: 8.2.1
+
+## Git Repository
+- Branch: work
+- Status: clean working tree
+
+## Workspace Layout Snapshot
+```
+app/:
+__pycache__
+core
+crud.py
+database.py
+dependencies.py
+init_db.py
+main.py
+models.py
+routes
+schemas.py
+services
+
+tests/:
+__pycache__
+conftest.py
+test_api_flow.py
+test_crud_players.py
+test_players.py
+test_seed.py
+test_services_elo.py
+test_services_matches.py
+test_services_tournaments.py
+test_services_wallet.py
+test_tournament_flow.py
+```
+
+## DB Models Snapshot
+```
+class TournamentType(str, enum.Enum):
+class TournamentStatus(str, enum.Enum):
+class TransactionType(str, enum.Enum):
+class Player(Base):
+class Tournament(Base):
+class Match(Base):
+class TournamentRegistration(Base):
+class TournamentResult(Base):
+class WalletTransaction(Base):
+```
+
+✅ Environment ready for next phase (test repair + CI integration).


### PR DESCRIPTION
## Summary
- record the environment, repository state, and snapshots requested for the dev session
- store command outputs in dev_session_log.md for future reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcd95e51d4832680e9207a68b10d8b