### PR TITLE
feat: scaffold react frontend

### DIFF
--- a/ROUTES_SETUP.md
+++ b/ROUTES_SETUP.md
@@ -1,0 +1,1 @@
+// index.tsx and App.tsx with routes and axios setup

--- a/__tests__/Profile.test.tsx
+++ b/__tests__/Profile.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Profile from '@/pages/Profile';
+import { AuthContext } from '@/context/AuthContext';
+import type { UserProfile } from '@/types/user';
+
+describe('Profile page', () => {
+  const createRefreshMock = () => jest.fn().mockResolvedValue(undefined);
+
+  it('shows loading indicator while profile is being fetched', () => {
+    const refreshProfile = createRefreshMock();
+    render(
+      <AuthContext.Provider value={{ isLoading: true, user: undefined, refreshProfile }}>
+        <Profile />
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByText(/loading your profile/i)).toBeInTheDocument();
+  });
+
+  it('shows a retry action when no user is loaded', () => {
+    const refreshProfile = createRefreshMock();
+    render(
+      <AuthContext.Provider value={{ isLoading: false, user: undefined, refreshProfile }}>
+        <Profile />
+      </AuthContext.Provider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(refreshProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders profile information for the authenticated user', () => {
+    const user: UserProfile = {
+      id: 'user-1',
+      username: 'Ronnie',
+      email: 'ronnie@example.com',
+      ranking: 1,
+      walletBalance: 50250,
+      favouriteCue: 'Custom ash'
+    };
+    const refreshProfile = createRefreshMock();
+
+    render(
+      <AuthContext.Provider value={{ isLoading: false, user, refreshProfile }}>
+        <Profile />
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByRole('heading', { name: /welcome back, ronnie/i })).toBeInTheDocument();
+    expect(screen.getByText(user.email)).toBeInTheDocument();
+    expect(screen.getByText(/50,250/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -1,0 +1,1 @@
+// Profile.test.tsx and Settings.test.tsx included

--- a/__tests__/Settings.test.tsx
+++ b/__tests__/Settings.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Settings from '@/pages/Settings';
+import { AuthContext } from '@/context/AuthContext';
+import type { UserProfile } from '@/types/user';
+
+function renderSettings(user?: UserProfile) {
+  return render(
+    <AuthContext.Provider value={{ isLoading: false, user, refreshProfile: jest.fn() }}>
+      <Settings />
+    </AuthContext.Provider>
+  );
+}
+
+describe('Settings page', () => {
+  it('submits preference updates and displays confirmation message', () => {
+    renderSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    expect(screen.getByText(/preferences saved/i)).toBeInTheDocument();
+  });
+
+  it('prefills the practice table using the player ranking', () => {
+    const user: UserProfile = {
+      id: 'user-1',
+      username: 'Judd',
+      email: 'judd@example.com',
+      ranking: 2,
+      walletBalance: 30000
+    };
+
+    renderSettings(user);
+
+    const input = screen.getByLabelText(/preferred practice table/i) as HTMLInputElement;
+    expect(input.value).toBe(String(user.ranking));
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src', '<rootDir>/__tests__'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@pages/(.*)$': '<rootDir>/src/pages/$1',
+    '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@api/(.*)$': '<rootDir>/src/api/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/']
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "snooker-tournaments-hybrid",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Clean architecture for managing snooker tournaments with a React frontend.",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "start": "echo \"No dev server configured. Add a bundler to run the frontend.\" && exit 1",
+    "test": "jest"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.16.5",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Snooker Tournaments Hybrid</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,28 @@
+import { Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '@/context/AuthContext';
+import AppLayout from '@/components/AppLayout';
+import Home from '@/pages/Home';
+import Dashboard from '@/pages/Dashboard';
+import Login from '@/pages/Login';
+import Wallet from '@/pages/Wallet';
+import Profile from '@/pages/Profile';
+import Settings from '@/pages/Settings';
+import NotFound from '@/pages/NotFound';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route index element={<Home />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="login" element={<Login />} />
+          <Route path="wallet" element={<Wallet />} />
+          <Route path="profile" element={<Profile />} />
+          <Route path="settings" element={<Settings />} />
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Routes>
+    </AuthProvider>
+  );
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.REACT_APP_API_URL ?? 'http://localhost:8000',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  withCredentials: true
+});
+
+export default api;

--- a/src/components/AppLayout.css
+++ b/src/components/AppLayout.css
@@ -1,0 +1,80 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--background, #0f172a);
+  color: var(--text, #e2e8f0);
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  padding: 2rem 1rem;
+  box-shadow: inset -1px 0 0 rgba(15, 23, 42, 0.6);
+}
+
+.logo {
+  margin: 0 0 2rem;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.sidebar .active {
+  color: #38bdf8;
+}
+
+.content {
+  padding: 2rem;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.15), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.1), transparent 40%);
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page h2 {
+  margin-top: 0;
+}
+
+.card {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+@media (max-width: 768px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,0 +1,38 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import './AppLayout.css';
+
+const navItems = [
+  { to: '/', label: 'Home' },
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/wallet', label: 'Wallet' },
+  { to: '/profile', label: 'Profile' },
+  { to: '/settings', label: 'Settings' }
+];
+
+export function AppLayout() {
+  return (
+    <div className="app-layout">
+      <aside className="sidebar">
+        <h1 className="logo">Snooker Hybrid</h1>
+        <nav>
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.to}>
+                <NavLink to={item.to} end={item.to === '/'}>
+                  {({ isActive }) => (
+                    <span className={isActive ? 'active' : undefined}>{item.label}</span>
+                  )}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      <main className="content">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+export default AppLayout;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import api from '@api/client';
+import type { UserProfile } from '@/types/user';
+
+interface AuthContextValue {
+  isLoading: boolean;
+  user?: UserProfile;
+  refreshProfile: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export interface AuthProviderProps {
+  readonly children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<UserProfile>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refreshProfile = async () => {
+    try {
+      setIsLoading(true);
+      const response = await api.get<UserProfile>('/users/me');
+      setUser(response.data);
+    } catch (error) {
+      console.warn('Unable to load profile', error);
+      setUser(undefined);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshProfile();
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      isLoading,
+      user,
+      refreshProfile
+    }),
+    [isLoading, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+
+  return context;
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,7 @@
+import { useAuthContext } from '@/context/AuthContext';
+
+export function useAuth() {
+  return useAuthContext();
+}
+
+export default useAuth;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Failed to find the root element.');
+}
+
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,25 @@
+const mockFixtures = [
+  { id: 'fixture-1', title: 'Quarter Final - Table 1', status: 'In Progress', table: 1 },
+  { id: 'fixture-2', title: 'Quarter Final - Table 2', status: 'Scheduled', table: 2 },
+  { id: 'fixture-3', title: 'Quarter Final - Table 3', status: 'Completed', table: 3 }
+];
+
+export default function Dashboard() {
+  return (
+    <section className="page" aria-labelledby="dashboard-heading">
+      <h2 id="dashboard-heading">Operations dashboard</h2>
+      <p>Monitor fixtures, player availability, and venue readiness in a single view.</p>
+
+      <div role="list" aria-label="Upcoming fixtures" style={{ display: 'grid', gap: '1rem' }}>
+        {mockFixtures.map((fixture) => (
+          <article key={fixture.id} role="listitem" className="card">
+            <h3>{fixture.title}</h3>
+            <p>
+              Table {fixture.table} · <strong>{fixture.status}</strong>
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+export default function Home() {
+  return (
+    <section className="page" aria-labelledby="home-heading">
+      <h2 id="home-heading">Snooker Tournaments Hybrid</h2>
+      <p>
+        Manage professional snooker tournaments with real-time insights, player analytics, and
+        wallet tracking. Navigate through the dashboard to review live fixtures or head to the wallet
+        area to reconcile payouts.
+      </p>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Link to="/dashboard">View dashboard</Link>
+        <Link to="/login">Sign in</Link>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,53 @@
+import { FormEvent, useState } from 'react';
+import api from '@api/client';
+import useAuth from '@/hooks/useAuth';
+
+export default function Login() {
+  const { refreshProfile, isLoading } = useAuth();
+  const [error, setError] = useState<string>();
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get('email');
+    const password = formData.get('password');
+
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      setError('Please provide both email and password.');
+      return;
+    }
+
+    try {
+      await api.post('/auth/login', { email, password });
+      await refreshProfile();
+    } catch (err) {
+      setError('Unable to sign in with the provided credentials.');
+      console.error(err);
+    }
+  };
+
+  return (
+    <section className="page" aria-labelledby="login-heading">
+      <h2 id="login-heading">Sign in to continue</h2>
+      <p>Access the operations hub and manage live tournament data.</p>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '1rem', maxWidth: '400px' }}>
+        <label htmlFor="email">
+          Email
+          <input id="email" name="email" type="email" required />
+        </label>
+        <label htmlFor="password">
+          Password
+          <input id="password" name="password" type="password" required />
+        </label>
+        <button type="submit" disabled={isLoading}>
+          {isLoading ? 'Signing in…' : 'Sign in'}
+        </button>
+        {error ? (
+          <p role="alert" style={{ color: '#f87171' }}>
+            {error}
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export default function NotFound() {
+  return (
+    <section className="page" aria-labelledby="not-found-heading">
+      <h2 id="not-found-heading">Page not found</h2>
+      <p>The page you are looking for does not exist. Return to the dashboard to continue.</p>
+      <Link to="/">Go to home</Link>
+    </section>
+  );
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,52 @@
+import useAuth from '@/hooks/useAuth';
+
+export default function Profile() {
+  const { user, isLoading, refreshProfile } = useAuth();
+
+  if (isLoading) {
+    return (
+      <section className="page" aria-busy="true" aria-labelledby="profile-heading">
+        <h2 id="profile-heading">Profile</h2>
+        <p>Loading your profile…</p>
+      </section>
+    );
+  }
+
+  if (!user) {
+    return (
+      <section className="page" aria-labelledby="profile-heading">
+        <h2 id="profile-heading">Profile</h2>
+        <p>No profile information available. Please sign in.</p>
+        <button type="button" onClick={() => refreshProfile()}>
+          Retry
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="page" aria-labelledby="profile-heading">
+      <h2 id="profile-heading">Welcome back, {user.username}</h2>
+      <dl>
+        <div>
+          <dt>Email</dt>
+          <dd>{user.email}</dd>
+        </div>
+        <div>
+          <dt>World ranking</dt>
+          <dd>{user.ranking}</dd>
+        </div>
+        <div>
+          <dt>Wallet balance</dt>
+          <dd>£{user.walletBalance.toLocaleString()}</dd>
+        </div>
+        {user.favouriteCue ? (
+          <div>
+            <dt>Favourite cue</dt>
+            <dd>{user.favouriteCue}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,43 @@
+import { FormEvent, useState } from 'react';
+import useAuth from '@/hooks/useAuth';
+
+export default function Settings() {
+  const { user } = useAuth();
+  const [message, setMessage] = useState('');
+
+  const handlePreferences = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setMessage('Preferences saved. These changes will sync with the backend when connected.');
+  };
+
+  return (
+    <section className="page" aria-labelledby="settings-heading">
+      <h2 id="settings-heading">Settings</h2>
+      <p>Control notification preferences and tournament visibility options.</p>
+      <form onSubmit={handlePreferences} style={{ display: 'grid', gap: '1rem', maxWidth: '420px' }}>
+        <fieldset>
+          <legend>Notifications</legend>
+          <label>
+            <input type="checkbox" name="notifyResults" defaultChecked /> Notify me about match results
+          </label>
+          <label>
+            <input type="checkbox" name="notifyPayments" defaultChecked /> Alert me about wallet updates
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Availability</legend>
+          <label>
+            Preferred practice table
+            <input type="number" name="practiceTable" min={1} max={8} defaultValue={user?.ranking ?? 1} />
+          </label>
+        </fieldset>
+        <button type="submit">Save preferences</button>
+        {message ? (
+          <p role="status" style={{ color: '#4ade80' }}>
+            {message}
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/src/pages/Wallet.tsx
+++ b/src/pages/Wallet.tsx
@@ -1,0 +1,39 @@
+const transactions = [
+  { id: 'tx-1', description: 'Player payout - Semi Final', amount: -1500 },
+  { id: 'tx-2', description: 'Ticket revenue - Session A', amount: 4200 },
+  { id: 'tx-3', description: 'Sponsorship bonus', amount: 2500 }
+];
+
+const currency = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' });
+
+export default function Wallet() {
+  const balance = transactions.reduce((acc, tx) => acc + tx.amount, 0);
+
+  return (
+    <section className="page" aria-labelledby="wallet-heading">
+      <h2 id="wallet-heading">Tournament wallet</h2>
+      <p>Track payouts, sponsorship deals, and real-time ticket revenue.</p>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <strong>Current balance:</strong> {currency.format(balance)}
+      </div>
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th align="left">Description</th>
+            <th align="right">Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((tx) => (
+            <tr key={tx.id}>
+              <td style={{ padding: '0.5rem 0' }}>{tx.description}</td>
+              <td style={{ padding: '0.5rem 0' }} align="right">
+                {currency.format(tx.amount)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const content: Record<string, string>;
+  export default content;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,9 @@
+export interface UserProfile {
+  id: string;
+  username: string;
+  email: string;
+  favouriteCue?: string;
+  ranking: number;
+  walletBalance: number;
+  avatarUrl?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"],
+      "@pages/*": ["pages/*"],
+      "@components/*": ["components/*"],
+      "@api/*": ["api/*"]
+    }
+  },
+  "include": ["src", "__tests__"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript React scaffold with routing, layout, and shared auth context
- configure axios client, typed hooks, and UI pages for home, dashboard, wallet, profile, settings, and login
- introduce testing setup with ts-jest and examples for the profile and settings pages

## Testing
- not run (frontend dependencies cannot be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe87d07b808326b2061dfa81221b82